### PR TITLE
adding kubectl to the help output if the binary is used as kubectl kurt

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,7 +27,9 @@ func init() {
 	rootCmd.PersistentFlags().IntVarP(&limitFlag, "limit", "c", 5, "Limit the number of resources you want to see. Set limit to 0 for no limits. Must be positive.\nFor example: \"kurt all -c=10\"")
 
 	if strings.HasPrefix(filepath.Base(os.Args[0]), "kubectl-") {
-		rootCmd.SetUsageTemplate(strings.ReplaceAll(rootCmd.UsageString(), "kurt", "kubectl kurt"))
+		rootCmd.SetUsageTemplate(strings.NewReplacer(
+			"{{.UseLine}}", "kubectl {{.UseLine}}",
+			"{{.CommandPath}}", "kubectl {{.CommandPath}}").Replace(rootCmd.UsageTemplate()))
 	}
 
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds `kubectl` to the help output if using as a kubectl plugin. Following best practices for https://github.com/kubernetes-sigs/krew-index/pull/1681

To test, build the binary and save it in your path as `kubectl-kurt` and run `kubectl kurt -h` and you should see the customized output

