### PR TITLE
Adding krew install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Head over to our [releases page](https://github.com/soraro/kurt/releases/latest)
 kubectl krew install kurt
 ```
 
+[Easy install for krew](https://krew.sh/)
+
 # Examples
 Show the top 5 highest restart counts grouped by `Namespace`, `Node`, `Label`, and `Pod`:
 ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ Use "kurt [command] --help" for more information about a command.
 ```
 
 # Install
-Head over to our [releases page](https://github.com/soraro/kurt/releases/latest)
+Head over to our [releases page](https://github.com/soraro/kurt/releases/latest) or run as a `kubectl` plugin with [krew](https://krew.sigs.k8s.io/)
+```
+kubectl krew install kurt
+```
 
 # Examples
 Show the top 5 highest restart counts grouped by `Namespace`, `Node`, `Label`, and `Pod`:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,10 @@ Head over to our [releases page](https://github.com/soraro/kurt/releases/latest)
 kubectl krew install kurt
 ```
 
-[Easy install for krew](https://krew.sh/)
+Easily install krew and kurt with the following:
+```
+curl https://krew.sh/kurt | bash
+```
 
 # Examples
 Show the top 5 highest restart counts grouped by `Namespace`, `Node`, `Label`, and `Pod`:


### PR DESCRIPTION
#### What this PR does / why we need it:
Update install instruction in the README to include krew plugin