### PR TITLE
Add cli flag to output individual container restarts in a pod

### DIFF
--- a/cmd/collect_test.go
+++ b/cmd/collect_test.go
@@ -5,7 +5,6 @@ import (
 )
 
 func TestTrackNamespaces(t *testing.T) {
-	namespaceTracker = make(map[string]int32)
 	trackNamespaces("ns1", 5)
 	trackNamespaces("ns1", 2)
 
@@ -15,7 +14,6 @@ func TestTrackNamespaces(t *testing.T) {
 }
 
 func TestTrackNodes(t *testing.T) {
-	nodeTracker = make(map[string]int32)
 	trackNodes("node01", 5)
 	trackNodes("node01", 2)
 	trackNodes("node02", 2)
@@ -26,7 +24,6 @@ func TestTrackNodes(t *testing.T) {
 }
 
 func TestTrackPods(t *testing.T) {
-	podTracker = make(map[string]int32)
 	// Test that a pod with the same name in a different namespace is held uniquely in the map
 	trackPods("pod1", "default", 3)
 	trackPods("pod1", "other", 2)
@@ -35,8 +32,15 @@ func TestTrackPods(t *testing.T) {
 	}
 }
 
+func TestTrackContainers(t *testing.T) {
+	initializeContainerMap("pod1", "default")
+	trackContainers("pod1", "default", "container1", 5)
+	if containerTracker["default:pod1"]["container1"] != 5 {
+		t.Errorf("pod1/container1 expected to have a count of 5 but instead shows: %v", containerTracker)
+	}
+}
+
 func TestTrackLabels(t *testing.T) {
-	labelTracker = make(map[string]int32)
 	tlabels := []string{"app", "k8s-app"}
 	plabelsA := map[string]string{
 		"app":   "app1",

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -1,9 +1,10 @@
 package cmd
 
-var namespaceTracker map[string]int32
-var nodeTracker map[string]int32
-var podTracker map[string]int32
-var labelTracker map[string]int32
+var namespaceTracker = make(map[string]int32)
+var nodeTracker = make(map[string]int32)
+var podTracker = make(map[string]int32)
+var labelTracker = make(map[string]int32)
+var containerTracker = make(map[string]map[string]int32)
 
 var printAll bool
 var printNS bool

--- a/cmd/printer_test.go
+++ b/cmd/printer_test.go
@@ -7,9 +7,10 @@ import (
 
 func Test_returnSortedLimit(t *testing.T) {
 	type args struct {
-		data    map[string]int32
-		limit   int
-		parseNS bool
+		data       map[string]int32
+		limit      int
+		parseNS    bool
+		containers map[string]map[string]int32
 	}
 	tests := []struct {
 		name string
@@ -27,34 +28,40 @@ func Test_returnSortedLimit(t *testing.T) {
 					"test5": 0,
 					"test6": 4,
 				},
-				limit:   5,
-				parseNS: false,
+				limit:      5,
+				parseNS:    false,
+				containers: nil,
 			},
 			want: ItemList{
 				Item{
-					Name:      "test4",
-					Count:     9,
-					Namespace: "",
+					Name:       "test4",
+					Count:      9,
+					Namespace:  "",
+					Containers: nil,
 				},
 				Item{
-					Name:      "test3",
-					Count:     8,
-					Namespace: "",
+					Name:       "test3",
+					Count:      8,
+					Namespace:  "",
+					Containers: nil,
 				},
 				Item{
-					Name:      "test2",
-					Count:     7,
-					Namespace: "",
+					Name:       "test2",
+					Count:      7,
+					Namespace:  "",
+					Containers: nil,
 				},
 				Item{
-					Name:      "test1",
-					Count:     5,
-					Namespace: "",
+					Name:       "test1",
+					Count:      5,
+					Namespace:  "",
+					Containers: nil,
 				},
 				Item{
-					Name:      "test6",
-					Count:     4,
-					Namespace: "",
+					Name:       "test6",
+					Count:      4,
+					Namespace:  "",
+					Containers: nil,
 				},
 			},
 		},
@@ -71,32 +78,45 @@ func Test_returnSortedLimit(t *testing.T) {
 				},
 				limit:   5,
 				parseNS: true,
+				containers: map[string]map[string]int32{
+					"test1:pod1": {"container1": 5},
+					"test2:pod2": {"container1": 7},
+					"test2:pod3": {"container1": 8},
+					"test1:pod4": {"container3": 2, "container1": 4, "container2": 3},
+					"test2:pod5": {"container1": 0},
+					"test1:pod6": {"container1": 4},
+				},
 			},
 			want: ItemList{
 				Item{
-					Name:      "pod4",
-					Count:     9,
-					Namespace: "test1",
+					Name:       "pod4",
+					Count:      9,
+					Namespace:  "test1",
+					Containers: Containers{Container{"container1", 4}, Container{"container2", 3}, Container{"container3", 2}},
 				},
 				Item{
-					Name:      "pod3",
-					Count:     8,
-					Namespace: "test2",
+					Name:       "pod3",
+					Count:      8,
+					Namespace:  "test2",
+					Containers: Containers{Container{"container1", 8}},
 				},
 				Item{
-					Name:      "pod2",
-					Count:     7,
-					Namespace: "test2",
+					Name:       "pod2",
+					Count:      7,
+					Namespace:  "test2",
+					Containers: Containers{Container{"container1", 7}},
 				},
 				Item{
-					Name:      "pod1",
-					Count:     5,
-					Namespace: "test1",
+					Name:       "pod1",
+					Count:      5,
+					Namespace:  "test1",
+					Containers: Containers{Container{"container1", 5}},
 				},
 				Item{
-					Name:      "pod6",
-					Count:     4,
-					Namespace: "test1",
+					Name:       "pod6",
+					Count:      4,
+					Namespace:  "test1",
+					Containers: Containers{Container{"container1", 4}},
 				},
 			},
 		},
@@ -104,7 +124,7 @@ func Test_returnSortedLimit(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := returnSortedLimit(tt.args.data, tt.args.limit, tt.args.parseNS); !reflect.DeepEqual(got, tt.want) {
+			if got := returnSortedLimit(tt.args.data, tt.args.limit, tt.args.parseNS, tt.args.containers); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("returnSortedLimit() = %v, want %v", got, tt.want)
 			}
 		})

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ import (
 
 var inamespace []string
 var ilabels []string
+var ishowContainers bool
 var limitFlag int
 var output string
 
@@ -27,6 +28,10 @@ func init() {
 	rootCmd.PersistentFlags().StringSliceVarP(&ilabels, "label", "l", []string{""}, "Specify multiple times for the label keys you want to see.\nFor example: \"kurt all -l app\"")
 	rootCmd.PersistentFlags().IntVarP(&limitFlag, "limit", "c", 5, "Limit the number of resources you want to see. Set limit to 0 for no limits. Must be positive.\nFor example: \"kurt all -c=10\"")
 	rootCmd.PersistentFlags().StringVarP(&output, "output", "o", "standard", "Specify output type. Options are: json, yaml, standard\nFor example: \"kurt all -o json\"")
+
+	// command specific flags
+	cmdPods.PersistentFlags().BoolVarP(&ishowContainers, "show-containers", "", false, "Show specific container restart counts for pods\nFor example: \"kurt pods --show-containers\"")
+	cmdAll.PersistentFlags().BoolVarP(&ishowContainers, "show-containers", "", false, "Show specific container restart counts for pods\nFor example: \"kurt pods --show-containers\"")
 
 	if strings.HasPrefix(filepath.Base(os.Args[0]), "kubectl-") {
 		rootCmd.SetUsageTemplate(strings.NewReplacer(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please file an issue before making a pull request.
2. Discussion for issues should go on the issue and code review should not PRs.
-->

#### What this PR does / why we need it:
Adds the flag `--show-containers` to optionally show the individual container restart counts in a multi-container pod.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #40 

#### How to test:
First, build a `kurt` binary from this branch:
```
go build
```

Use the following `pod.yml` file to create a simple multi-container pod, and apply it to a cluster:
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: myapp
spec:
  containers:
  - name: nginx
    image: nginx:latest
    ports:
    - containerPort: 80
  - name: busybox
    image: busybox:latest
    command: ['sh', '-c', 'echo "Hello world" && sleep 3600']
```

Then, force a container restart:
```bash
kubectl exec -it -c nginx myapp -- bash -c "kill 1"
```

Finally, run `kurt` with and without the `--show-contianers` flag:

**Examples:**
(without the flag)
`$ ./kurt pods`
```
kurt: KUbernetes Restart Tracker

==========

 Pod                                    Namespace       Restarts
 
 myapp                                  default         1
 kube-apiserver-minikube                kube-system     0
 kube-controller-manager-minikube       kube-system     0
 kube-proxy-8nktc                       kube-system     0
 kube-scheduler-minikube                kube-system     0
```

(with the flag)
`$ ./kurt pods --show-containers`
```
kurt: KUbernetes Restart Tracker

==========

 Pod                            Namespace       Restarts
 
 myapp                          default         1
    └nginx: 1
    └busybox: 0
 kube-scheduler-minikube        kube-system     0
    └kube-scheduler: 0
 storage-provisioner            kube-system     0
    └storage-provisioner: 0
 coredns-78fcd69978-pqgq2       kube-system     0
    └coredns: 0
 etcd-minikube                  kube-system     0
    └etcd: 0
```

(JSON output)
`$ ./kurt pods -o json`
```json
{
  "pods": [
    {
      "name": "myapp",
      "count": 1,
      "namespace": "default",
      "containers": [
        {
          "name": "nginx",
          "count": 1
        },
        {
          "name": "busybox",
          "count": 0
        }
      ]
    },
    {
      "name": "kube-apiserver-minikube",
      "count": 0,
      "namespace": "kube-system",
      "containers": [
        {
          "name": "kube-apiserver",
          "count": 0
        }
      ]
    },
    {
      "name": "kube-controller-manager-minikube",
      "count": 0,
      "namespace": "kube-system",
      "containers": [
        {
          "name": "kube-controller-manager",
          "count": 0
        }
      ]
    },
    {
      "name": "kube-proxy-8nktc",
      "count": 0,
      "namespace": "kube-system",
      "containers": [
        {
          "name": "kube-proxy",
          "count": 0
        }
      ]
    },
    {
      "name": "kube-scheduler-minikube",
      "count": 0,
      "namespace": "kube-system",
      "containers": [
        {
          "name": "kube-scheduler",
          "count": 0
        }
      ]
    }
  ]
}
```