### PR TITLE
Add e2e tests in CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,35 @@
+name: e2e tests
+on:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  run-e2e-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          # get these here: https://github.com/kubernetes-sigs/kind/releases
+          - version: "1.24"
+            image: kindest/node:v1.24.0@sha256:0866296e693efe1fed79d5e6c7af8df71fc73ae45e3679af05342239cdc5bc8e
+          - version: "1.23"
+            image: kindest/node:v1.23.6@sha256:b1fa224cc6c7ff32455e0b1fd9cbfd3d3bc87ecaa8fcb06961ed1afb3db0f9ae
+          - version: "1.22"
+            image: kindest/node:v1.22.9@sha256:8135260b959dfe320206eb36b3aeda9cffcb262f4b44cda6b33f7bb73f453105
+          - version: "1.21"
+            image: kindest/node:v1.21.12@sha256:f316b33dd88f8196379f38feb80545ef3ed44d9197dca1bfd48bcb1583210207
+          - version: "1.20"
+            image: kindest/node:v1.20.15@sha256:6f2d011dffe182bad80b85f6c00e8ca9d86b5b8922cdf433d53575c4c5212248
+    steps:
+      - name: Create k8s Kind Cluster - ${{ matrix.version }}
+        uses: helm/kind-action@v1.3.0
+        with:
+          node_image: ${{ matrix.image }}
+      - name: Show cluster version
+        run: kubectl version
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "1.17"
+      - uses: actions/checkout@v2
+      - run: go build
+      - name: e2e test
+        run: tests/e2e.sh

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -eou pipefail
+
+kubectl apply -f tests/test.yml --wait
+kubectl wait --for=condition=Ready pod/nginx -n test1
+kubectl wait --for=condition=Ready pod/apache -n test2
+
+# Generate some pod restarts
+kubectl exec nginx -n test1 -- bash -c "kill 1"
+
+kubectl exec apache -n test2 -- bash -c "kill 1"
+
+sleep 5
+kubectl exec nginx -n test1 -- bash -c "kill 1"
+
+echo "[!] wait for pods to finish restarting..."
+sleep 30
+
+NGINX_RESTARTS=$(./kurt pods -n test1 -o json | jq '.pods[0].count')
+if [ $NGINX_RESTARTS -eq 2 ]; then
+    echo "[+] Correct number of restarts for nginx 👍"
+else
+    echo "[!] Incorrect number of restarts for nginx: $NGINX_RESTARTS"
+    exit 1
+fi
+
+APACHE_RESTARTS=$(./kurt pods -n test2 -o json | jq '.pods[0].count')
+if [ $APACHE_RESTARTS -eq 1 ]; then
+    echo "[+] Correct number of restarts for apache 👍"
+else
+    echo "[!] Incorrect number of restarts for apache: $APACHE_RESTARTS"
+    exit 1
+fi
+
+echo "[+] Cleaning up..."
+kubectl delete -f tests/test.yml

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,0 +1,29 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: test1
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: test2
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  namespace: test1
+spec:
+  containers:
+  - name: nginx
+    image: nginx:latest
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: apache
+  namespace: test2
+spec:
+  containers:
+  - name: apache
+    image: httpd:latest


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds a very basic e2e test on the latest 5 versions of kubernetes. This basic bash script effectively creates some pods, forces some restarts, runs `kurt` and validates that the number of restarts is what we expect. 

This script can and *should* be improved, but I'm hoping this is a good place to start and will hopefully allow us to be more confident with dependabot PR's. This is more or less the test I'm doing today manually.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #16 
