### PR TITLE
Update to use golang 1.21 and e2e test K8s versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.19"
+          go-version: "1.21"
       - uses: actions/checkout@v2
       - run: go build
 
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.19"
+          go-version: "1.21"
       - uses: actions/checkout@v2
       - run: go test ./cmd -v
 
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.19"
+          go-version: "1.21"
       - uses: actions/checkout@v2
       - run: |
           if

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,19 +9,19 @@ jobs:
       matrix:
         include:
           # get these here: https://github.com/kubernetes-sigs/kind/releases
+          - version: "1.28"
+            image: kindest/node:v1.28.0@sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31
+          - version: "1.27"
+            image: kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
+          - version: "1.26"
+            image: kindest/node:v1.26.6@sha256:6e2d8b28a5b601defe327b98bd1c2d1930b49e5d8c512e1895099e4504007adb
+          - version: "1.25"
+            image: kindest/node:v1.25.11@sha256:227fa11ce74ea76a0474eeefb84cb75d8dad1b08638371ecf0e86259b35be0c8
           - version: "1.24"
-            image: kindest/node:v1.24.0@sha256:0866296e693efe1fed79d5e6c7af8df71fc73ae45e3679af05342239cdc5bc8e
-          - version: "1.23"
-            image: kindest/node:v1.23.6@sha256:b1fa224cc6c7ff32455e0b1fd9cbfd3d3bc87ecaa8fcb06961ed1afb3db0f9ae
-          - version: "1.22"
-            image: kindest/node:v1.22.9@sha256:8135260b959dfe320206eb36b3aeda9cffcb262f4b44cda6b33f7bb73f453105
-          - version: "1.21"
-            image: kindest/node:v1.21.12@sha256:f316b33dd88f8196379f38feb80545ef3ed44d9197dca1bfd48bcb1583210207
-          - version: "1.20"
-            image: kindest/node:v1.20.15@sha256:6f2d011dffe182bad80b85f6c00e8ca9d86b5b8922cdf433d53575c4c5212248
+            image: kindest/node:v1.24.15@sha256:7db4f8bea3e14b82d12e044e25e34bd53754b7f2b0e9d56df21774e6f66a70ab
     steps:
       - name: Create k8s Kind Cluster - ${{ matrix.version }}
-        uses: helm/kind-action@v1.3.0
+        uses: helm/kind-action@v1.5.0
         with:
           node_image: ${{ matrix.image }}
       - name: Show cluster version

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,7 @@ jobs:
         run: kubectl version
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.19"
+          go-version: "1.21"
       - uses: actions/checkout@v2
       - run: go build
       - name: e2e test

--- a/.github/workflows/go-releaser.yml
+++ b/.github/workflows/go-releaser.yml
@@ -18,7 +18,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19
+          go-version: 1.21
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ kubectl delete pod $POD -n $NS
 As seen in the [`cmd/collect.go` file](https://github.com/soraro/kurt/blob/main/cmd/collect.go) the only permission required for kurt is `pods/list`.
 
 # Requirements
-Go Version 1.19
+Go Version 1.21
 
 # Building
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module kurt
 
-go 1.19
+go 1.21
 
 require (
 	github.com/spf13/cobra v1.7.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please file an issue before making a pull request.
2. Discussion for issues should go on the issue and code review should not PRs.
-->

#### What this PR does / why we need it: 
Updates the project to golang 1.21 for K8s dependencies and updates the e2e tests to use the latest K8s versions.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Should fix dependabot issue on #95 
