### PR TITLE
update e2e test matrix

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,6 +9,12 @@ jobs:
       matrix:
         include:
           # get these here: https://github.com/kubernetes-sigs/kind/releases
+          - version: "1.32"
+            image: kindest/node:v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027
+          - version: "1.31"
+            image: kindest/node:v1.31.4@sha256:2cb39f7295fe7eafee0842b1052a599a4fb0f8bcf3f83d96c7f4864c357c6c30
+          - version: "1.30"
+            image: kindest/node:v1.30.8@sha256:17cd608b3971338d9180b00776cb766c50d0a0b6b904ab4ff52fd3fc5c6369bf
           - version: "1.29"
             image: kindest/node:v1.29.2@sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245
           - version: "1.28"
@@ -17,12 +23,6 @@ jobs:
             image: kindest/node:v1.27.11@sha256:681253009e68069b8e01aad36a1e0fa8cf18bb0ab3e5c4069b2e65cafdd70843
           - version: "1.26"
             image: kindest/node:v1.26.14@sha256:5d548739ddef37b9318c70cb977f57bf3e5015e4552be4e27e57280a8cbb8e4f
-          - version: "1.25"
-            image: kindest/node:v1.25.16@sha256:e8b50f8e06b44bb65a93678a65a26248fae585b3d3c2a669e5ca6c90c69dc519
-          - version: "1.24"
-            image: kindest/node:v1.24.17@sha256:bad10f9b98d54586cba05a7eaa1b61c6b90bfc4ee174fdc43a7b75ca75c95e51
-          - version: "1.23"
-            image: kindest/node:v1.23.17@sha256:14d0a9a892b943866d7e6be119a06871291c517d279aedb816a4b4bc0ec0a5b3
     steps:
       - name: Create k8s Kind Cluster - ${{ matrix.version }}
         uses: helm/kind-action@v1.5.0


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR updates which versions of kubernetes we test against. 
